### PR TITLE
Add support for dynamic command registration

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/AllTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/AllTests.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4e.test;
 
 import org.eclipse.lsp4e.test.codeactions.CodeActionTests;
+import org.eclipse.lsp4e.test.commands.DynamicRegistrationTest;
 import org.eclipse.lsp4e.test.completion.CompleteCompletionTest;
 import org.eclipse.lsp4e.test.completion.ContextInformationTest;
 import org.eclipse.lsp4e.test.completion.IncompleteCompletionTest;
@@ -55,7 +56,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	CodeActionTests.class,
 	DocumentLinkTest.class,
 	RunningLanguageServerTest.class,
-	HighlightTest.class
+	HighlightTest.class,
+	DynamicRegistrationTest.class
 })
 public class AllTests {
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Pivotal Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Kris De Volder - Initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.test.TestUtils;
+import org.eclipse.lsp4e.tests.mock.MockLanguageSever;
+import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.Unregistration;
+import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkspaceFoldersOptions;
+import org.eclipse.lsp4j.WorkspaceServerCapabilities;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.ui.PlatformUI;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class DynamicRegistrationTest {
+
+	private static final String WORKSPACE_EXECUTE_COMMAND = "workspace/executeCommand";
+	private static final String WORKSPACE_DID_CHANGE_FOLDERS = "workspace/didChangeWorkspaceFolders";
+
+	private IProject project;
+
+	@Before
+	public void setUp() throws Exception {
+		MockLanguageSever.reset();
+		LanguageServiceAccessor.clearStartedServers();
+		project = TestUtils.createProject("CommandRegistrationTest" + System.currentTimeMillis());
+		IFile testFile = TestUtils.createFile(project, "shouldUseExtension.lspt", "");
+
+		// Make sure mock language server is created...
+		LanguageServer info = LanguageServiceAccessor
+				.getInitializedLanguageServers(testFile, capabilites -> Boolean.TRUE).iterator().next()
+				.get(1, TimeUnit.SECONDS);
+		assertNotNull(info);
+	}
+
+	@After
+	public void tearDown() throws CoreException {
+		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
+		project.delete(true, true, new NullProgressMonitor());
+	}
+
+	@Test
+	public void testCommandRegistration() throws Exception {
+		@NonNull List<@NonNull LanguageServer> servers = LanguageServiceAccessor.getLanguageServers(c -> true);
+		assertEquals(1, servers.size());
+
+		assertTrue(LanguageServiceAccessor.getLanguageServers(handlesCommand("test.command")).isEmpty());
+		
+		UUID registration = registerCommands("test.command", "test.command.2");
+		try {
+			assertEquals(1, LanguageServiceAccessor.getLanguageServers(handlesCommand("test.command")).size());
+			assertEquals(1, LanguageServiceAccessor.getLanguageServers(handlesCommand("test.command.2")).size());
+		} finally {
+			unregister(registration);
+		}
+		assertTrue(LanguageServiceAccessor.getLanguageServers(handlesCommand("test.command")).isEmpty());
+		assertTrue(LanguageServiceAccessor.getLanguageServers(handlesCommand("test.command.2")).isEmpty());
+	}
+
+	@Test
+	public void testWorkspaceFoldersRegistration() throws Exception {
+		@NonNull List<@NonNull LanguageServer> servers = LanguageServiceAccessor.getLanguageServers(c -> true);
+		assertEquals(1, servers.size());
+
+		assertTrue(LanguageServiceAccessor.getLanguageServers(c -> hasWorkspaceFolderSupport(c)).isEmpty());
+
+		UUID registration = registerWorkspaceFolders();
+		try {
+			assertEquals(1, LanguageServiceAccessor.getLanguageServers(c -> hasWorkspaceFolderSupport(c)).size());
+		} finally {
+			unregister(registration);
+		}
+		assertTrue(LanguageServiceAccessor.getLanguageServers(c -> hasWorkspaceFolderSupport(c)).isEmpty());
+		assertEquals(1, LanguageServiceAccessor.getLanguageServers(c -> !hasWorkspaceFolderSupport(c)).size());
+	}
+
+	//////////////////////////////////////////////////////////////////////////////////
+
+	private void unregister(UUID registration) throws Exception {
+		LanguageClient client = getMockClient();
+		Unregistration unregistration = new Unregistration(registration.toString(), WORKSPACE_EXECUTE_COMMAND);
+		client.unregisterCapability(new UnregistrationParams(Arrays.asList(unregistration)))
+		.get(1, TimeUnit.SECONDS);
+	}
+
+	private UUID registerWorkspaceFolders() throws Exception {
+		UUID id = UUID.randomUUID();
+		LanguageClient client = getMockClient();
+		Registration registration = new Registration();
+		registration.setId(id.toString());
+		registration.setMethod(WORKSPACE_DID_CHANGE_FOLDERS);
+		client.registerCapability(new RegistrationParams(Arrays.asList(registration)))
+		.get(1, TimeUnit.SECONDS);
+		return id;
+	}
+
+	private UUID registerCommands(String... command) throws Exception {
+		UUID id = UUID.randomUUID();
+		LanguageClient client = getMockClient();
+		Registration registration = new Registration();
+		registration.setId(id.toString());
+		registration.setMethod(WORKSPACE_EXECUTE_COMMAND);
+		registration.setRegisterOptions(new Gson().toJsonTree(new ExecuteCommandOptions(Arrays.asList(command))));
+		client.registerCapability(new RegistrationParams(Arrays.asList(registration))).get(1, TimeUnit.SECONDS);
+		return id;
+	}
+
+	private LanguageClient getMockClient() {
+		List<LanguageClient> proxies = MockLanguageSever.INSTANCE.getRemoteProxies();
+		assertEquals(1, proxies.size());
+		return proxies.get(0);
+	}
+
+	private Predicate<ServerCapabilities> handlesCommand(String command) {
+		return (cap) -> {
+			ExecuteCommandOptions commandProvider = cap.getExecuteCommandProvider();
+			return commandProvider != null && commandProvider.getCommands().contains(command);
+		};
+	}
+
+	private boolean hasWorkspaceFolderSupport(ServerCapabilities cap) {
+		if (cap != null) {
+			WorkspaceServerCapabilities ws = cap.getWorkspace();
+			if (ws != null) {
+				WorkspaceFoldersOptions f = ws.getWorkspaceFolders();
+				if (f != null) {
+					return f.getSupported();
+				}
+			}
+		}
+		return false;
+	}
+
+}

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageSever.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageSever.java
@@ -8,7 +8,8 @@
  * Contributors:
  *  Michał Niewrzał (Rogue Wave Software Inc.) - initial implementation
  *  Mickael Istria (Red Hat Inc.) - added support for delays
- *  Lucas Bullen (Red Hat Inc.) - Bug 508458 - Add support for codelens
+ *  Lucas Bullen (Red Hat Inc.) - Bug 508458 - Add support for codelens.
+ *  Kris De Volder (Pivotal Inc.) - Provide test code access to Client proxy.
  *******************************************************************************/
 package org.eclipse.lsp4e.tests.mock;
 
@@ -21,6 +22,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 
+import org.eclipse.lsp4j.CodeLens;
+import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionOptions;
@@ -33,8 +36,6 @@ import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkOptions;
 import org.eclipse.lsp4j.Hover;
-import org.eclipse.lsp4j.CodeLens;
-import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.Location;
@@ -59,6 +60,8 @@ public final class MockLanguageSever implements LanguageServer {
 	private long delay = 0;
 	private boolean started;
 
+	private List<LanguageClient> remoteProxies = new ArrayList<>();
+
 	public static void reset() {
 		INSTANCE = new MockLanguageSever();
 	}
@@ -81,6 +84,7 @@ public final class MockLanguageSever implements LanguageServer {
 
 	public void addRemoteProxy(LanguageClient remoteProxy) {
 		this.textDocumentService.addRemoteProxy(remoteProxy);
+		this.remoteProxies.add(remoteProxy);
 		this.started = true;
 	}
 
@@ -110,6 +114,7 @@ public final class MockLanguageSever implements LanguageServer {
 					throw new RuntimeException(e);
 				}
 			}).thenApply(new Function<Void, U>() {
+				@Override
 				public U apply(Void v) {
 					return value;
 				}
@@ -224,6 +229,10 @@ public final class MockLanguageSever implements LanguageServer {
 
 	public boolean isRunning() {
 		return this.started;
+	}
+
+	public List<LanguageClient> getRemoteProxies() {
+		return remoteProxies;
 	}
 
 }


### PR DESCRIPTION
- handles registration and deregistration of `workspace/executeCommand`
  capability.

- adds a method to LanguageServiceAccessor to facilitate retrieving
  active language server(s) capable of handling a command
  (Actually the method allows retrieving language server based on
  any capability predicate, finding command handlers is one way of using
  it.

Signed-off-by: Kris De Volder <kdevolder@pivotal.io>